### PR TITLE
Fix EnvironmentObject preview crash

### DIFF
--- a/WorkoutProgressApp/ContentView.swift
+++ b/WorkoutProgressApp/ContentView.swift
@@ -837,4 +837,6 @@ extension Color {
 
 #Preview {
     ContentView()
+        .environmentObject(WorkoutViewModel())
+        .environmentObject(WorkoutBlockManager.withSampleData())
 }


### PR DESCRIPTION
## Summary
- fix crash in `ContentView` preview by injecting missing environment objects

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6850b03235688326a91e5d605ad1da40