### PR TITLE
Enable Block rename

### DIFF
--- a/WorkoutProgressApp/BlockModel.swift
+++ b/WorkoutProgressApp/BlockModel.swift
@@ -10,10 +10,15 @@ import SwiftUI
 
 // MARK: - WorkoutBlock Model
 
-struct WorkoutBlock: Identifiable {
+struct WorkoutBlock: Identifiable, Equatable {
     var blockID: CKRecord.ID?
     var title: String
     var order: Int // Property to track block order
+    var accentColorHex: String = "#1E88E5"
+
+    var accentColor: Color {
+        Color(hex: accentColorHex)
+    }
     
     // Conform to Identifiable with a String ID that is guaranteed to be unique
     var id: String {
@@ -29,11 +34,13 @@ struct WorkoutBlock: Identifiable {
         self.blockID = record.recordID
         self.title = record["title"] as? String ?? ""
         self.order = record["order"] as? Int ?? 0
+        self.accentColorHex = record["accentColorHex"] as? String ?? "#1E88E5"
     }
-    
+
     init(title: String, order: Int = 0) {
         self.title = title
         self.order = order
+        self.accentColorHex = "#1E88E5"
     }
     
     func toCKRecord() -> CKRecord {
@@ -45,6 +52,7 @@ struct WorkoutBlock: Identifiable {
         }
         record["title"] = title as CKRecordValue
         record["order"] = order as CKRecordValue
+        record["accentColorHex"] = accentColorHex as CKRecordValue
         return record
     }
 }
@@ -191,7 +199,7 @@ class WorkoutBlockManager: ObservableObject {
     }
 
     // Update an existing block
-    func updateBlock(block: WorkoutBlock, newTitle: String) {
+    func updateBlock(block: WorkoutBlock, newTitle: String? = nil, newColor: String? = nil) {
         // Use blockID (the CKRecord.ID) instead of id (the String)
         guard let recordID = block.blockID else {
             print("Error: Block has no record ID.")
@@ -205,7 +213,12 @@ class WorkoutBlockManager: ObservableObject {
             }
             
             if let fetchedRecord = fetchedRecord {
-                fetchedRecord["title"] = newTitle as CKRecordValue
+                if let newTitle = newTitle {
+                    fetchedRecord["title"] = newTitle as CKRecordValue
+                }
+                if let newColor = newColor {
+                    fetchedRecord["accentColorHex"] = newColor as CKRecordValue
+                }
                 self.privateDB.save(fetchedRecord) { updatedRecord, error in
                     if let error = error {
                         print("Error updating block: \(error.localizedDescription)")
@@ -219,7 +232,7 @@ class WorkoutBlockManager: ObservableObject {
                             if let index = self.blocks.firstIndex(where: { $0.id == block.id }) {
                                 self.blocks[index] = updatedBlock
                             }
-                            print("Successfully updated block. New title: \(updatedBlock.title)")
+                            print("Successfully updated block. New title: \(updatedBlock.title), New color: \(updatedBlock.accentColorHex)")
                         }
                     } else {
                         print("Error: No record returned after updating block.")

--- a/WorkoutProgressApp/BlockView.swift
+++ b/WorkoutProgressApp/BlockView.swift
@@ -185,6 +185,9 @@ struct BlockCardView: View {
     
     /// State to control sheet presentation
     @State private var showReorderSheet = false
+
+    /// Temporary title used when renaming a block
+    @State private var editedTitle: String = ""
     
     /// A pre-calculated rotation angle if you still want the 3D effect in a TabView.
     let rotationAngle: Double
@@ -201,34 +204,48 @@ struct BlockCardView: View {
     var body: some View {
         ZStack {
             if isEditing {
-                     // In editing mode, the entire card displays buttons
-                     BlockCustomRoundedRectangle()
-                         .overlay(
-                             VStack(spacing: 16) {
-                                 Button(action: {
-                                     withAnimation {
-                                         blockManager.deleteBlock(block: block)
-                                         isEditing = false
-                                     }
-                                 }) {
-                                     Text("Delete Block")
-                                         .font(.headline)
-                                         .foregroundColor(.white)
-                                         .padding()
-                                 }
-                                 
-                                 Button(action: {
-                                     showReorderSheet = true
-                                     isEditing = false // Close editing mode when moving
-                                 }) {
-                                     Text("Reorder Blocks")
-                                         .font(.headline)
-                                         .foregroundColor(.white)
-                                         .padding()
-                                 }
-                             }
-                         )
-                 } else {
+                // In editing mode, the entire card displays controls
+                BlockCustomRoundedRectangle()
+                    .overlay(
+                        VStack(spacing: 16) {
+                            TextField("Block Name", text: $editedTitle)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .padding(.horizontal)
+
+                            Button("Save Name") {
+                                let newName = editedTitle.trimmingCharacters(in: .whitespaces)
+                                guard !newName.isEmpty else { return }
+                                blockManager.updateBlock(block: block, newTitle: newName)
+                                isEditing = false
+                            }
+                            .disabled(editedTitle.trimmingCharacters(in: .whitespaces).isEmpty)
+                            .padding(.bottom, 8)
+
+                            Button(action: {
+                                withAnimation {
+                                    blockManager.deleteBlock(block: block)
+                                    isEditing = false
+                                }
+                            }) {
+                                Text("Delete Block")
+                                    .font(.headline)
+                                    .foregroundColor(.white)
+                                    .padding()
+                            }
+
+                            Button(action: {
+                                showReorderSheet = true
+                                isEditing = false // Close editing mode when moving
+                            }) {
+                                Text("Reorder Blocks")
+                                    .font(.headline)
+                                    .foregroundColor(.white)
+                                    .padding()
+                            }
+                        }
+                    )
+                    .onAppear { editedTitle = block.title }
+            } else {
                 
                 // If NOT editing, the entire card is a NavigationLink.
                 NavigationLink(

--- a/WorkoutProgressApp/BlockView.swift
+++ b/WorkoutProgressApp/BlockView.swift
@@ -188,6 +188,10 @@ struct BlockCardView: View {
 
     /// Temporary title used when renaming a block
     @State private var editedTitle: String = ""
+
+    /// Color picker state
+    @State private var showColorPicker = false
+    @State private var selectedColor: Color = .blue
     
     /// A pre-calculated rotation angle if you still want the 3D effect in a TabView.
     let rotationAngle: Double
@@ -205,53 +209,107 @@ struct BlockCardView: View {
         ZStack {
             if isEditing {
                 // In editing mode, the entire card displays controls
-                BlockCustomRoundedRectangle()
+                BlockCustomRoundedRectangle(accentColor: block.accentColor)
                     .overlay(
-                        VStack(spacing: 16) {
+                        VStack {
+                            HStack(spacing: 55) {
+                                Button(action: {
+                                    withAnimation { isEditing.toggle() }
+                                }) {
+                                    Image(systemName: "arrow.left")
+                                        .font(.system(size: 24, weight: .bold))
+                                        .frame(width: 44, height: 44)
+                                        .background(Color.black.opacity(0.22))
+                                        .foregroundColor(.white)
+                                        .clipShape(Circle())
+                                        .overlay(
+                                            Circle().stroke(Color.white.opacity(0.2), lineWidth: 1.2)
+                                        )
+                                }
+                                .buttonStyle(.borderless)
+
+                                Button(action: {
+                                    selectedColor = block.accentColor
+                                    showColorPicker = true
+                                }) {
+                                    Image(systemName: "pencil")
+                                        .font(.system(size: 24, weight: .bold))
+                                        .frame(width: 44, height: 44)
+                                        .background(Color.black.opacity(0.22))
+                                        .foregroundColor(.white)
+                                        .clipShape(Circle())
+                                        .overlay(
+                                            Circle().stroke(Color.white.opacity(0.2), lineWidth: 1.2)
+                                        )
+                                }
+                                .buttonStyle(.borderless)
+
+                                Button(action: {
+                                    blockManager.deleteBlock(block: block)
+                                    isEditing = false
+                                }) {
+                                    Image(systemName: "trash")
+                                        .font(.system(size: 24, weight: .bold))
+                                        .frame(width: 44, height: 44)
+                                        .background(Color.black.opacity(0.22))
+                                        .foregroundColor(.red)
+                                        .clipShape(Circle())
+                                        .overlay(
+                                            Circle().stroke(Color.red.opacity(0.25), lineWidth: 2)
+                                        )
+                                }
+                                .buttonStyle(.borderless)
+                            }
+                            .padding([.top, .horizontal], 0)
+
                             TextField("Block Name", text: $editedTitle)
                                 .textFieldStyle(RoundedBorderTextFieldStyle())
-                                .padding(.horizontal)
+                                .padding()
 
                             Button("Save Name") {
                                 let newName = editedTitle.trimmingCharacters(in: .whitespaces)
                                 guard !newName.isEmpty else { return }
-                                blockManager.updateBlock(block: block, newTitle: newName)
+                                var newColorHex: String? = nil
+                                if let newHex = selectedColor.toHex(), newHex != block.accentColorHex {
+                                    newColorHex = newHex
+                                }
+                                blockManager.updateBlock(block: block, newTitle: newName, newColor: newColorHex)
                                 isEditing = false
                             }
                             .disabled(editedTitle.trimmingCharacters(in: .whitespaces).isEmpty)
                             .padding(.bottom, 8)
 
-                            Button(action: {
-                                withAnimation {
-                                    blockManager.deleteBlock(block: block)
-                                    isEditing = false
-                                }
-                            }) {
-                                Text("Delete Block")
-                                    .font(.headline)
-                                    .foregroundColor(.white)
-                                    .padding()
-                            }
+                            Spacer().frame(height: 130)
 
                             Button(action: {
                                 showReorderSheet = true
-                                isEditing = false // Close editing mode when moving
+                                isEditing = false
                             }) {
                                 Text("Reorder Blocks")
-                                    .font(.headline)
+                                    .font(.system(size: 14, weight: .semibold, design: .rounded))
                                     .foregroundColor(.white)
-                                    .padding()
+                                    .padding(.horizontal, 24)
+                                    .padding(.vertical, 11)
+                                    .frame(maxWidth: 180)
                             }
+                            .buttonStyle(NeumorphicButtonStyle(accent: Color("NeomorphBG5")))
+                            .padding(.bottom, 28)
                         }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background(Color.black.opacity(0.001))
+                    , alignment: .top
                     )
-                    .onAppear { editedTitle = block.title }
+                    .onAppear {
+                        editedTitle = block.title
+                        selectedColor = block.accentColor
+                    }
             } else {
                 
                 // If NOT editing, the entire card is a NavigationLink.
                 NavigationLink(
                     destination: BlockWorkoutsListView(blockTitle: block.title)
                 ) {
-                    BlockCustomRoundedRectangle()
+                    BlockCustomRoundedRectangle(accentColor: block.accentColor)
                         .overlay(
                             ZStack {
                                 Text(block.title)
@@ -313,6 +371,20 @@ struct BlockCardView: View {
                 // Navigate to block detail
                 // Your existing navigation code
             }
+        }
+        .sheet(isPresented: $showColorPicker) {
+            VStack {
+                ColorPicker("Accent Color", selection: $selectedColor, supportsOpacity: false)
+                    .padding()
+                Button("Save") {
+                    if let newHex = selectedColor.toHex() {
+                        blockManager.updateBlock(block: block, newColor: newHex)
+                    }
+                    showColorPicker = false
+                }
+                .padding()
+            }
+            .presentationDetents([.fraction(0.3)])
         }
         .sheet(isPresented: $showReorderSheet) {
             BlockReorderSheet(blockManager: blockManager, isPresented: $showReorderSheet)

--- a/WorkoutProgressApp/ColorHex.swift
+++ b/WorkoutProgressApp/ColorHex.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3:
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6:
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8:
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (1, 1, 1, 0)
+        }
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+
+    func toHex() -> String? {
+        let uic = UIColor(self)
+        guard let components = uic.cgColor.components, components.count >= 3 else {
+            return nil
+        }
+        let r = Float(components[0])
+        let g = Float(components[1])
+        let b = Float(components[2])
+        return String(format: "#%02lX%02lX%02lX", lroundf(r * 255), lroundf(g * 255), lroundf(b * 255))
+    }
+}


### PR DESCRIPTION
## Summary
- add temporary title state for editing
- provide text field and save button when editing a block so user can rename it

## Testing
- `swift test -c release` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6854bbb23e2483268c29b51c93e5d395